### PR TITLE
Add initial MoneyFlow app skeleton

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["@babel/preset-env", "@babel/preset-react"]
+}

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# Example environment variables for mofl
+PORT=3001
+DB_HOST=localhost
+DB_PORT=5432
+DB_USER=your_db_user
+DB_PASSWORD=your_db_password
+DB_NAME=mofldb
+JWT_SECRET=your_jwt_secret

--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
-# mofl
+# mofl (MoneyFlow)
+
+A minimalist personal accounting app demonstrating magic-link authentication and expressive Material 3 styling.
+
+## Development
+
+```bash
+npm install
+npm run dev
+```
+
+The dev script runs both the Express API server and the React development server.
+
+Create a `.env` file based on `.env.example` with your PostgreSQL credentials and JWT secret.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "mofl",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "start": "node server/index.js",
+    "client": "webpack serve --mode development",
+    "dev": "concurrently \"npm run start\" \"npm run client\""
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "pg": "^8.10.0",
+    "jsonwebtoken": "^9.0.0",
+    "bcrypt": "^5.1.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.4.0",
+    "@reduxjs/toolkit": "^1.9.5",
+    "react-redux": "^8.1.1",
+    "@mui/material": "^5.13.5",
+    "@mui/icons-material": "^5.13.5",
+    "@emotion/react": "^11.10.6",
+    "@emotion/styled": "^11.10.6",
+    "@fontsource/noto-sans": "^4.5.12",
+    "i18next": "^22.4.7",
+    "react-i18next": "^13.0.1",
+    "axios": "^1.4.0"
+  },
+  "devDependencies": {
+    "webpack": "^5.88.2",
+    "webpack-cli": "^5.1.4",
+    "webpack-dev-server": "^4.15.1",
+    "concurrently": "^8.2.0",
+    "babel-loader": "^9.1.3",
+    "@babel/core": "^7.22.9",
+    "@babel/preset-env": "^7.22.9",
+    "@babel/preset-react": "^7.18.6"
+  }
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>mofl - MoneyFlow</title>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans&display=swap" />
+</head>
+<body>
+  <div id="root"></div>
+  <script src="/bundle.js"></script>
+</body>
+</html>

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,101 @@
+// Basic Express server for mofl
+// Handles magic link authentication and transaction CRUD
+const express = require('express');
+const jwt = require('jsonwebtoken');
+const { Pool } = require('pg');
+const bodyParser = require('body-parser');
+require('dotenv').config();
+
+const app = express();
+const pool = new Pool(); // uses environment variables for config
+
+app.use(bodyParser.json());
+
+// Middleware to authenticate requests with JWT token in Authorization header
+function authMiddleware(req, res, next) {
+  const authHeader = req.headers.authorization;
+  if (!authHeader) return res.status(401).json({ error: 'Missing token' });
+  const token = authHeader.replace('Bearer ', '');
+  try {
+    const payload = jwt.verify(token, process.env.JWT_SECRET);
+    req.user = payload;
+    next();
+  } catch (e) {
+    res.status(401).json({ error: 'Invalid token' });
+  }
+}
+
+// POST /api/auth/login - generate magic link token (in real app email would be sent)
+app.post('/api/auth/login', async (req, res) => {
+  const { email, name } = req.body;
+  if (!email || !name) return res.status(400).json({ error: 'Missing fields' });
+  // In a real implementation we would create user if not exists and email a magic link
+  const token = jwt.sign({ email, name }, process.env.JWT_SECRET, { expiresIn: '1h' });
+  console.log(`Magic link for ${email}: http://localhost:${process.env.PORT}/api/auth/verify?token=${token}`);
+  res.json({ message: 'Magic link generated. Check server log for token.' });
+});
+
+// GET /api/auth/verify - verify magic link token and return JWT for session
+app.get('/api/auth/verify', (req, res) => {
+  const { token } = req.query;
+  try {
+    const payload = jwt.verify(token, process.env.JWT_SECRET);
+    // Issue a new token used for authenticated requests
+    const sessionToken = jwt.sign({ email: payload.email }, process.env.JWT_SECRET, { expiresIn: '7d' });
+    res.json({ token: sessionToken });
+  } catch (e) {
+    res.status(400).json({ error: 'Invalid or expired token' });
+  }
+});
+
+// Transactions CRUD
+app.get('/api/transactions', authMiddleware, async (req, res) => {
+  try {
+    const result = await pool.query('SELECT * FROM transactions WHERE user_email = $1 ORDER BY date DESC', [req.user.email]);
+    res.json(result.rows);
+  } catch (e) {
+    res.status(500).json({ error: 'Database error' });
+  }
+});
+
+app.post('/api/transactions', authMiddleware, async (req, res) => {
+  const { amount, date, category, source, description } = req.body;
+  try {
+    const result = await pool.query(
+      'INSERT INTO transactions (user_email, amount, date, category, source, description) VALUES ($1,$2,$3,$4,$5,$6) RETURNING *',
+      [req.user.email, amount, date, category, source, description]
+    );
+    res.json(result.rows[0]);
+  } catch (e) {
+    res.status(500).json({ error: 'Database error' });
+  }
+});
+
+app.put('/api/transactions/:id', authMiddleware, async (req, res) => {
+  const { id } = req.params;
+  const { amount, date, category, source, description } = req.body;
+  try {
+    const result = await pool.query(
+      'UPDATE transactions SET amount=$1, date=$2, category=$3, source=$4, description=$5 WHERE id=$6 AND user_email=$7 RETURNING *',
+      [amount, date, category, source, description, id, req.user.email]
+    );
+    res.json(result.rows[0]);
+  } catch (e) {
+    res.status(500).json({ error: 'Database error' });
+  }
+});
+
+app.delete('/api/transactions/:id', authMiddleware, async (req, res) => {
+  const { id } = req.params;
+  try {
+    await pool.query('DELETE FROM transactions WHERE id=$1 AND user_email=$2', [id, req.user.email]);
+    res.json({ id });
+  } catch (e) {
+    res.status(500).json({ error: 'Database error' });
+  }
+});
+
+const port = process.env.PORT || 3001;
+app.listen(port, () => {
+  console.log(`Server running on port ${port}`);
+});

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { ThemeProvider, CssBaseline } from '@mui/material';
+import { BrowserRouter, Routes, Route, Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import '@fontsource/noto-sans';
+import Dashboard from './pages/Dashboard';
+import Transactions from './pages/Transactions';
+import Categories from './pages/Categories';
+import Settings from './pages/Settings';
+import Login from './pages/Login';
+import theme from './theme';
+
+export default function App() {
+  const { t } = useTranslation();
+  return (
+    <ThemeProvider theme={theme}>
+      <CssBaseline />
+      <BrowserRouter>
+        <nav>
+          <Link to="/">{t('dashboard')}</Link> |{' '}
+          <Link to="/transactions">{t('transactions')}</Link> |{' '}
+          <Link to="/categories">{t('categories')}</Link> |{' '}
+          <Link to="/settings">{t('settings')}</Link>
+        </nav>
+        <Routes>
+          <Route path="/" element={<Dashboard />} />
+          <Route path="/transactions" element={<Transactions />} />
+          <Route path="/categories" element={<Categories />} />
+          <Route path="/settings" element={<Settings />} />
+          <Route path="/login" element={<Login />} />
+        </Routes>
+      </BrowserRouter>
+    </ThemeProvider>
+  );
+}

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1,0 +1,10 @@
+{
+  "dashboard": "Dashboard",
+  "transactions": "Transactions",
+  "categories": "Categories",
+  "settings": "Settings",
+  "login": "Login",
+  "totalSpent": "Spent this month",
+  "totalIncome": "Income",
+  "balance": "Balance"
+}

--- a/src/i18n/index.js
+++ b/src/i18n/index.js
@@ -1,0 +1,16 @@
+import i18n from 'i18next';
+import { initReactI18next } from 'react-i18next';
+import ko from './ko.json';
+import en from './en.json';
+
+i18n.use(initReactI18next).init({
+  resources: {
+    ko: { translation: ko },
+    en: { translation: en },
+  },
+  lng: 'ko',
+  fallbackLng: 'en',
+  interpolation: { escapeValue: false },
+});
+
+export default i18n;

--- a/src/i18n/ko.json
+++ b/src/i18n/ko.json
@@ -1,0 +1,10 @@
+{
+  "dashboard": "대시보드",
+  "transactions": "거래내역",
+  "categories": "카테고리",
+  "settings": "설정",
+  "login": "로그인",
+  "totalSpent": "이번 달 지출",
+  "totalIncome": "총 수입",
+  "balance": "잔액"
+}

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { Provider } from 'react-redux';
+import store from './store/store';
+import App from './App';
+import './i18n';
+
+const root = createRoot(document.getElementById('root'));
+root.render(
+  <Provider store={store}>
+    <App />
+  </Provider>
+);
+

--- a/src/pages/Categories.jsx
+++ b/src/pages/Categories.jsx
@@ -1,0 +1,3 @@
+export default function Categories() {
+  return <div>Categories</div>;
+}

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -1,0 +1,30 @@
+import React, { useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { Card, CardContent, Typography } from '@mui/material';
+import { useTranslation } from 'react-i18next';
+import { fetchTransactions } from '../store/transactionsSlice';
+
+export default function Dashboard() {
+  const { t } = useTranslation();
+  const dispatch = useDispatch();
+  const transactions = useSelector((state) => state.transactions.items);
+
+  useEffect(() => {
+    dispatch(fetchTransactions());
+  }, [dispatch]);
+
+  const totalSpent = transactions.reduce((sum, t) => sum + (t.amount < 0 ? -t.amount : 0), 0);
+  const totalIncome = transactions.reduce((sum, t) => sum + (t.amount > 0 ? t.amount : 0), 0);
+  const balance = totalIncome - totalSpent;
+
+  return (
+    <Card sx={{ m: 2 }}>
+      <CardContent>
+        <Typography variant="h5">{t('dashboard')}</Typography>
+        <Typography>{t('totalSpent')}: {totalSpent}</Typography>
+        <Typography>{t('totalIncome')}: {totalIncome}</Typography>
+        <Typography>{t('balance')}: {balance}</Typography>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -1,0 +1,31 @@
+import React, { useState } from 'react';
+import { useDispatch } from 'react-redux';
+import axios from 'axios';
+import { TextField, Button } from '@mui/material';
+import { setToken } from '../store/authSlice';
+
+export default function Login() {
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const dispatch = useDispatch();
+
+  const handleSubmit = async () => {
+    await axios.post('/api/auth/login', { name, email });
+    alert('Check server console for magic link token');
+  };
+
+  const handleVerify = async () => {
+    const token = prompt('Enter token from server log');
+    const res = await axios.get(`/api/auth/verify?token=${token}`);
+    dispatch(setToken(res.data.token));
+  };
+
+  return (
+    <div>
+      <TextField label="Name" value={name} onChange={(e) => setName(e.target.value)} />
+      <TextField label="Email" value={email} onChange={(e) => setEmail(e.target.value)} />
+      <Button variant="contained" onClick={handleSubmit}>Request Link</Button>
+      <Button onClick={handleVerify}>Enter Token</Button>
+    </div>
+  );
+}

--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -1,0 +1,3 @@
+export default function Settings() {
+  return <div>Settings</div>;
+}

--- a/src/pages/Transactions.jsx
+++ b/src/pages/Transactions.jsx
@@ -1,0 +1,23 @@
+import React, { useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { List, ListItem, ListItemText } from '@mui/material';
+import { fetchTransactions } from '../store/transactionsSlice';
+
+export default function Transactions() {
+  const dispatch = useDispatch();
+  const transactions = useSelector((state) => state.transactions.items);
+
+  useEffect(() => {
+    dispatch(fetchTransactions());
+  }, [dispatch]);
+
+  return (
+    <List>
+      {transactions.map((t) => (
+        <ListItem key={t.id} divider>
+          <ListItemText primary={`${t.description} - ${t.amount}`} secondary={t.date} />
+        </ListItem>
+      ))}
+    </List>
+  );
+}

--- a/src/store/authSlice.js
+++ b/src/store/authSlice.js
@@ -1,0 +1,17 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+const authSlice = createSlice({
+  name: 'auth',
+  initialState: { token: null },
+  reducers: {
+    setToken(state, action) {
+      state.token = action.payload;
+    },
+    logout(state) {
+      state.token = null;
+    },
+  },
+});
+
+export const { setToken, logout } = authSlice.actions;
+export default authSlice.reducer;

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -1,0 +1,10 @@
+import { configureStore } from '@reduxjs/toolkit';
+import authReducer from './authSlice';
+import transactionsReducer from './transactionsSlice';
+
+export default configureStore({
+  reducer: {
+    auth: authReducer,
+    transactions: transactionsReducer,
+  },
+});

--- a/src/store/transactionsSlice.js
+++ b/src/store/transactionsSlice.js
@@ -1,0 +1,21 @@
+import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
+import axios from 'axios';
+
+export const fetchTransactions = createAsyncThunk('transactions/fetch', async (_, { getState }) => {
+  const token = getState().auth.token;
+  const res = await axios.get('/api/transactions', { headers: { Authorization: `Bearer ${token}` } });
+  return res.data;
+});
+
+const transactionsSlice = createSlice({
+  name: 'transactions',
+  initialState: { items: [] },
+  reducers: {},
+  extraReducers: (builder) => {
+    builder.addCase(fetchTransactions.fulfilled, (state, action) => {
+      state.items = action.payload;
+    });
+  },
+});
+
+export default transactionsSlice.reducer;

--- a/src/theme.js
+++ b/src/theme.js
@@ -1,0 +1,18 @@
+import { createTheme } from '@mui/material/styles';
+
+// Simple expressive Material 3 theme with custom accent color
+const theme = createTheme({
+  palette: {
+    primary: {
+      main: '#6750A4',
+    },
+    secondary: {
+      main: '#486284',
+    },
+  },
+  typography: {
+    fontFamily: 'Noto Sans, sans-serif',
+  },
+});
+
+export default theme;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,41 @@
+const path = require('path');
+
+module.exports = {
+  entry: './src/index.jsx',
+  output: {
+    path: path.resolve(__dirname, 'dist'),
+    filename: 'bundle.js',
+    publicPath: '/',
+  },
+  resolve: {
+    extensions: ['.js', '.jsx'],
+  },
+  module: {
+    rules: [
+      {
+        test: /\.jsx?$/,
+        exclude: /node_modules/,
+        use: {
+          loader: 'babel-loader',
+          options: {
+            presets: ['@babel/preset-env', '@babel/preset-react'],
+          },
+        },
+      },
+      {
+        test: /\.css$/,
+        use: ['style-loader', 'css-loader'],
+      },
+    ],
+  },
+  devServer: {
+    static: {
+      directory: path.join(__dirname, 'public'),
+    },
+    historyApiFallback: true,
+    port: 3000,
+    proxy: {
+      '/api': 'http://localhost:3001',
+    },
+  },
+};


### PR DESCRIPTION
## Summary
- initialize express backend with JWT magic link authentication and transaction CRUD
- provide React frontend using Material 3 styling and Redux
- add i18n with Korean default and English fallback
- example environment variables and development instructions

## Testing
- `npm --version`
- `npm run client` *(fails: webpack not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847fd17c55c832dbaa33ef2c5838bc4